### PR TITLE
Add QR Code Feature

### DIFF
--- a/app/Http/Controllers/QRCodeController.php
+++ b/app/Http/Controllers/QRCodeController.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * UrlHum (https://urlhum.com)
+ *
+ * @link      https://github.com/urlhum/UrlHum
+ * @license   https://github.com/urlhum/UrlHum/blob/master/LICENSE.md (MIT License)
+ */
+
+namespace App\Http\Controllers;
+
+use App\Url;
+use Illuminate\Support\Facades\Storage;
+use SimpleSoftwareIO\QrCode\Facades\QrCode;
+
+/**
+ * Controller handling creating/fetching the QR code associated with the short URL.
+ *
+ * Class ViewUrlController
+ * @author Michael Lindahl <me@michaellindahl.com>
+ */
+class QRCodeController
+{
+    /**
+     * Retreives the QR Code in svg format for the short URL.
+     *
+     * @param $url
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function svg(Url $url)
+    {
+        return $this->qrCode($url, 'svg', 'image/svg+xml');
+    }
+
+    /**
+     * Retreives the QR Code in png format for the short URL.
+     *
+     * @param $url
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function png(Url $url)
+    {
+        return $this->qrCode($url, 'png', 'image/png');
+    }
+
+    private function qrCode(Url $url, $format, $contentType) 
+    {
+        $path = 'qrcodes/'.$url->short_url.'.'.$format;
+        if (Storage::exists($path)) {
+            $qrCode = Storage::get($path);
+        } else {
+            $qrCode = QrCode::format($format)->size(300)->generate(route('view', $url));
+            Storage::put($path, $qrCode);
+        }
+
+        return response($qrCode)->header('Content-Type', $contentType);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "laravel/framework": "5.8.*",
         "laravel/passport": "^7.2",
         "laravel/tinker": "^1.0",
+        "simplesoftwareio/simple-qrcode": "^2.0",
         "spatie/laravel-honeypot": "^1.3",
         "yajra/laravel-datatables-oracle": "~9.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "239138b9ce2516bbdabe92ca857a337a",
+    "content-hash": "fd0e2b25df5d2c347b0848eee40fadb3",
     "packages": [
         {
             "name": "anlutro/l4-settings",
@@ -64,6 +64,52 @@
             ],
             "description": "Persistent settings in Laravel.",
             "time": "2019-03-29T18:02:04+00:00"
+        },
+        {
+            "name": "bacon/bacon-qr-code",
+            "version": "1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Bacon/BaconQrCode.git",
+                "reference": "5a91b62b9d37cee635bbf8d553f4546057250bee"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Bacon/BaconQrCode/zipball/5a91b62b9d37cee635bbf8d553f4546057250bee",
+                "reference": "5a91b62b9d37cee635bbf8d553f4546057250bee",
+                "shasum": ""
+            },
+            "require": {
+                "ext-iconv": "*",
+                "php": "^5.4|^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8"
+            },
+            "suggest": {
+                "ext-gd": "to generate QR code images"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "BaconQrCode": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Ben Scholzen 'DASPRiD'",
+                    "email": "mail@dasprids.de",
+                    "homepage": "http://www.dasprids.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "BaconQrCode is a QR code generator for PHP.",
+            "homepage": "https://github.com/Bacon/BaconQrCode",
+            "time": "2017-10-17T09:59:25+00:00"
         },
         {
             "name": "composer/ca-bundle",
@@ -835,12 +881,12 @@
             "version": "4.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/ivanakimov/hashids.php.git",
+                "url": "https://github.com/vinkla/hashids.git",
                 "reference": "43bb2407f16a631f0128f47bcb67ff986c63dde2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ivanakimov/hashids.php/zipball/43bb2407f16a631f0128f47bcb67ff986c63dde2",
+                "url": "https://api.github.com/repos/vinkla/hashids/zipball/43bb2407f16a631f0128f47bcb67ff986c63dde2",
                 "reference": "43bb2407f16a631f0128f47bcb67ff986c63dde2",
                 "shasum": ""
             },
@@ -2554,6 +2600,67 @@
                 "uuid"
             ],
             "time": "2018-07-19T23:38:55+00:00"
+        },
+        {
+            "name": "simplesoftwareio/simple-qrcode",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/SimpleSoftwareIO/simple-qrcode.git",
+                "reference": "90b2282dd29be1e52565e9832dc23af41610ea07"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/SimpleSoftwareIO/simple-qrcode/zipball/90b2282dd29be1e52565e9832dc23af41610ea07",
+                "reference": "90b2282dd29be1e52565e9832dc23af41610ea07",
+                "shasum": ""
+            },
+            "require": {
+                "bacon/bacon-qr-code": "1.0.*",
+                "ext-gd": "*",
+                "illuminate/support": ">=5.0.0",
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "0.9.*",
+                "phpunit/phpunit": "~6"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "SimpleSoftwareIO\\QrCode\\QrCodeServiceProvider"
+                    ],
+                    "aliases": {
+                        "QrCode": "SimpleSoftwareIO\\QrCode\\Facades\\QrCode"
+                    }
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "SimpleSoftwareIO\\QrCode\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Simple Software LLC",
+                    "email": "support@simplesoftware.io"
+                }
+            ],
+            "description": "Simple QrCode is a QR code generator made for Laravel.",
+            "homepage": "http://www.simplesoftware.io",
+            "keywords": [
+                "Simple",
+                "generator",
+                "laravel",
+                "qrcode",
+                "wrapper"
+            ],
+            "time": "2017-11-26T15:27:12+00:00"
         },
         {
             "name": "spatie/laravel-honeypot",

--- a/resources/lang/af_ZA/url.php
+++ b/resources/lang/af_ZA/url.php
@@ -50,4 +50,7 @@ return [
   'latest' => 'Latest URLs',
   'all' => 'See all',
   'urls' => 'URLs',
+  'qrcode' => 'QR Code',
+  'qrcode_modal' => 'QR Code',
+  'qrcode_download' => 'Download',
 ];

--- a/resources/lang/ar_SA/url.php
+++ b/resources/lang/ar_SA/url.php
@@ -50,4 +50,7 @@ return [
   'latest' => 'Latest URLs',
   'all' => 'See all',
   'urls' => 'URLs',
+  'qrcode' => 'QR Code',
+  'qrcode_modal' => 'QR Code',
+  'qrcode_download' => 'Download',
 ];

--- a/resources/lang/ca_ES/url.php
+++ b/resources/lang/ca_ES/url.php
@@ -50,4 +50,7 @@ return [
   'latest' => 'Latest URLs',
   'all' => 'See all',
   'urls' => 'URLs',
+  'qrcode' => 'QR Code',
+  'qrcode_modal' => 'QR Code',
+  'qrcode_download' => 'Download',
 ];

--- a/resources/lang/cs_CZ/url.php
+++ b/resources/lang/cs_CZ/url.php
@@ -50,4 +50,7 @@ return [
   'latest' => 'Latest URLs',
   'all' => 'See all',
   'urls' => 'URLs',
+  'qrcode' => 'QR Code',
+  'qrcode_modal' => 'QR Code',
+  'qrcode_download' => 'Download',
 ];

--- a/resources/lang/da_DK/url.php
+++ b/resources/lang/da_DK/url.php
@@ -50,4 +50,7 @@ return [
   'latest' => 'Latest URLs',
   'all' => 'See all',
   'urls' => 'URLs',
+  'qrcode' => 'QR Code',
+  'qrcode_modal' => 'QR Code',
+  'qrcode_download' => 'Download',
 ];

--- a/resources/lang/de_DE/url.php
+++ b/resources/lang/de_DE/url.php
@@ -50,4 +50,7 @@ return [
   'latest' => 'Latest URLs',
   'all' => 'See all',
   'urls' => 'URLs',
+  'qrcode' => 'QR Code',
+  'qrcode_modal' => 'QR Code',
+  'qrcode_download' => 'Download',
 ];

--- a/resources/lang/el_GR/url.php
+++ b/resources/lang/el_GR/url.php
@@ -50,4 +50,7 @@ return [
   'latest' => 'Latest URLs',
   'all' => 'See all',
   'urls' => 'URLs',
+  'qrcode' => 'QR Code',
+  'qrcode_modal' => 'QR Code',
+  'qrcode_download' => 'Download',
 ];

--- a/resources/lang/en_US/url.php
+++ b/resources/lang/en_US/url.php
@@ -50,4 +50,7 @@ return [
   'latest' => 'Latest URLs',
   'all' => 'See all',
   'urls' => 'URLs',
+  'qrcode' => 'QR Code',
+  'qrcode_modal' => 'QR Code',
+  'qrcode_download' => 'Download',
 ];

--- a/resources/lang/es_ES/url.php
+++ b/resources/lang/es_ES/url.php
@@ -50,4 +50,7 @@ return [
   'latest' => 'Últimas URLs',
   'all' => 'Ver todo',
   'urls' => 'URLs',
+  'qrcode' => 'QR Code',
+  'qrcode_modal' => 'QR Code',
+  'qrcode_download' => 'Download',
 ];

--- a/resources/lang/fa_IR/url.php
+++ b/resources/lang/fa_IR/url.php
@@ -50,4 +50,7 @@ return [
   'latest' => 'Latest URLs',
   'all' => 'See all',
   'urls' => 'URLs',
+  'qrcode' => 'QR Code',
+  'qrcode_modal' => 'QR Code',
+  'qrcode_download' => 'Download',
 ];

--- a/resources/lang/fi_FI/url.php
+++ b/resources/lang/fi_FI/url.php
@@ -50,4 +50,7 @@ return [
   'latest' => 'Latest URLs',
   'all' => 'See all',
   'urls' => 'URLs',
+  'qrcode' => 'QR Code',
+  'qrcode_modal' => 'QR Code',
+  'qrcode_download' => 'Download',
 ];

--- a/resources/lang/fr_FR/url.php
+++ b/resources/lang/fr_FR/url.php
@@ -50,4 +50,7 @@ return [
   'latest' => 'Latest URLs',
   'all' => 'See all',
   'urls' => 'URLs',
+  'qrcode' => 'QR Code',
+  'qrcode_modal' => 'QR Code',
+  'qrcode_download' => 'Download',
 ];

--- a/resources/lang/he_IL/url.php
+++ b/resources/lang/he_IL/url.php
@@ -50,4 +50,7 @@ return [
   'latest' => 'Latest URLs',
   'all' => 'See all',
   'urls' => 'URLs',
+  'qrcode' => 'QR Code',
+  'qrcode_modal' => 'QR Code',
+  'qrcode_download' => 'Download',
 ];

--- a/resources/lang/hu_HU/url.php
+++ b/resources/lang/hu_HU/url.php
@@ -50,4 +50,7 @@ return [
   'latest' => 'Latest URLs',
   'all' => 'See all',
   'urls' => 'URLs',
+  'qrcode' => 'QR Code',
+  'qrcode_modal' => 'QR Code',
+  'qrcode_download' => 'Download',
 ];

--- a/resources/lang/it_IT/url.php
+++ b/resources/lang/it_IT/url.php
@@ -50,4 +50,7 @@ return [
   'latest' => 'Ultimi URL',
   'all' => 'Mostra tutti',
   'urls' => 'URL',
+  'qrcode' => 'QR Code',
+  'qrcode_modal' => 'QR Code',
+  'qrcode_download' => 'Download',
 ];

--- a/resources/lang/ja_JP/url.php
+++ b/resources/lang/ja_JP/url.php
@@ -50,4 +50,7 @@ return [
   'latest' => 'Latest URLs',
   'all' => 'See all',
   'urls' => 'URLs',
+  'qrcode' => 'QR Code',
+  'qrcode_modal' => 'QR Code',
+  'qrcode_download' => 'Download',
 ];

--- a/resources/lang/ko_KR/url.php
+++ b/resources/lang/ko_KR/url.php
@@ -50,4 +50,7 @@ return [
   'latest' => 'Latest URLs',
   'all' => 'See all',
   'urls' => 'URLs',
+  'qrcode' => 'QR Code',
+  'qrcode_modal' => 'QR Code',
+  'qrcode_download' => 'Download',
 ];

--- a/resources/lang/nl_NL/url.php
+++ b/resources/lang/nl_NL/url.php
@@ -50,4 +50,7 @@ return [
   'latest' => 'Latest URLs',
   'all' => 'See all',
   'urls' => 'URLs',
+  'qrcode' => 'QR Code',
+  'qrcode_modal' => 'QR Code',
+  'qrcode_download' => 'Download',
 ];

--- a/resources/lang/no_NO/url.php
+++ b/resources/lang/no_NO/url.php
@@ -50,4 +50,7 @@ return [
   'latest' => 'Latest URLs',
   'all' => 'See all',
   'urls' => 'URLs',
+  'qrcode' => 'QR Code',
+  'qrcode_modal' => 'QR Code',
+  'qrcode_download' => 'Download',
 ];

--- a/resources/lang/pl_PL/url.php
+++ b/resources/lang/pl_PL/url.php
@@ -50,4 +50,7 @@ return [
   'latest' => 'Latest URLs',
   'all' => 'See all',
   'urls' => 'URLs',
+  'qrcode' => 'QR Code',
+  'qrcode_modal' => 'QR Code',
+  'qrcode_download' => 'Download',
 ];

--- a/resources/lang/pt_BR/url.php
+++ b/resources/lang/pt_BR/url.php
@@ -50,4 +50,7 @@ return [
   'latest' => 'Latest URLs',
   'all' => 'See all',
   'urls' => 'URLs',
+  'qrcode' => 'QR Code',
+  'qrcode_modal' => 'QR Code',
+  'qrcode_download' => 'Download',
 ];

--- a/resources/lang/pt_PT/url.php
+++ b/resources/lang/pt_PT/url.php
@@ -50,4 +50,7 @@ return [
   'latest' => 'Latest URLs',
   'all' => 'See all',
   'urls' => 'URLs',
+  'qrcode' => 'QR Code',
+  'qrcode_modal' => 'QR Code',
+  'qrcode_download' => 'Download',
 ];

--- a/resources/lang/ro_RO/url.php
+++ b/resources/lang/ro_RO/url.php
@@ -50,4 +50,7 @@ return [
   'latest' => 'Latest URLs',
   'all' => 'See all',
   'urls' => 'URLs',
+  'qrcode' => 'QR Code',
+  'qrcode_modal' => 'QR Code',
+  'qrcode_download' => 'Download',
 ];

--- a/resources/lang/ru_RU/url.php
+++ b/resources/lang/ru_RU/url.php
@@ -50,4 +50,7 @@ return [
   'latest' => 'Latest URLs',
   'all' => 'See all',
   'urls' => 'URLs',
+  'qrcode' => 'QR Code',
+  'qrcode_modal' => 'QR Code',
+  'qrcode_download' => 'Download',
 ];

--- a/resources/lang/sr_SP/url.php
+++ b/resources/lang/sr_SP/url.php
@@ -50,4 +50,7 @@ return [
   'latest' => 'Latest URLs',
   'all' => 'See all',
   'urls' => 'URLs',
+  'qrcode' => 'QR Code',
+  'qrcode_modal' => 'QR Code',
+  'qrcode_download' => 'Download',
 ];

--- a/resources/lang/sv_SE/url.php
+++ b/resources/lang/sv_SE/url.php
@@ -50,4 +50,7 @@ return [
   'latest' => 'Latest URLs',
   'all' => 'See all',
   'urls' => 'URLs',
+  'qrcode' => 'QR Code',
+  'qrcode_modal' => 'QR Code',
+  'qrcode_download' => 'Download',
 ];

--- a/resources/lang/tr_TR/url.php
+++ b/resources/lang/tr_TR/url.php
@@ -50,4 +50,7 @@ return [
   'latest' => 'Latest URLs',
   'all' => 'See all',
   'urls' => 'URLs',
+  'qrcode' => 'QR Code',
+  'qrcode_modal' => 'QR Code',
+  'qrcode_download' => 'Download',
 ];

--- a/resources/lang/uk_UA/url.php
+++ b/resources/lang/uk_UA/url.php
@@ -50,4 +50,7 @@ return [
   'latest' => 'Latest URLs',
   'all' => 'See all',
   'urls' => 'URLs',
+  'qrcode' => 'QR Code',
+  'qrcode_modal' => 'QR Code',
+  'qrcode_download' => 'Download',
 ];

--- a/resources/lang/vi_VN/url.php
+++ b/resources/lang/vi_VN/url.php
@@ -50,4 +50,7 @@ return [
   'latest' => 'Latest URLs',
   'all' => 'See all',
   'urls' => 'URLs',
+  'qrcode' => 'QR Code',
+  'qrcode_modal' => 'QR Code',
+  'qrcode_download' => 'Download',
 ];

--- a/resources/lang/zh_CN/url.php
+++ b/resources/lang/zh_CN/url.php
@@ -50,4 +50,7 @@ return [
   'latest' => '最新URL',
   'all' => '查看所有',
   'urls' => 'URL',
+  'qrcode' => 'QR Code',
+  'qrcode_modal' => 'QR Code',
+  'qrcode_download' => 'Download',
 ];

--- a/resources/lang/zh_TW/url.php
+++ b/resources/lang/zh_TW/url.php
@@ -50,4 +50,7 @@ return [
   'latest' => 'Latest URLs',
   'all' => 'See all',
   'urls' => 'URLs',
+  'qrcode' => 'QR Code',
+  'qrcode_modal' => 'QR Code',
+  'qrcode_download' => 'Download',
 ];

--- a/resources/views/analytics/urlAnalytics.blade.php
+++ b/resources/views/analytics/urlAnalytics.blade.php
@@ -11,9 +11,15 @@
                                 <h1>{{ __('analytics.show.title') }}
                                     <a href="{{ url('/') }}/{{$url}}">{{ $url }}</a>
                                 </h1>
-                                @if ($isOwnerOrAdmin)
-                                    <a href="{{ url('/') }}/url/{{$url}}" class="btn btn-success">{{ __('url.edit.edit') }}</a>
-                                @endif
+
+                                <div>
+                                <button type="button" class="btn btn-info" id="qrModalButton" data-toggle="modal" data-target="#QRCodeModal">
+                                    <i class="fa fa-qrcode"></i> {{ __('url.qrcode') }}
+                                </button>
+                                    @if ($isOwnerOrAdmin)
+                                        <a href="{{ url('/') }}/url/{{$url}}" class="btn btn-success">{{ __('url.edit.edit') }}</a>
+                                    @endif
+                                </div>
                             </div>
                             <div class="card-body">
                                 <p>{{ __('url.created', ['date' => $creationDate]) }}</p>
@@ -182,6 +188,8 @@
                                 </div>
                                 {{ $referers->fragment('referrers-table')->links() }}
                             </div>
+
+                            @include('url.partials.qrcodemodal', ['url' => $url])
                         </div>
                     </div>
                 </div>

--- a/resources/views/url/edit.blade.php
+++ b/resources/views/url/edit.blade.php
@@ -61,6 +61,11 @@
                                 <a href="/{{$data->short_url}}+" class="btn btn-success">
                                     <i class="fa fa-chart-bar"></i> {{ __('url.stats') }}
                                 </a>
+
+                                <button type="button" class="btn btn-info" id="qrModalButton" data-toggle="modal" data-target="#QRCodeModal">
+                                    <i class="fa fa-qrcode"></i> {{ __('url.qrcode') }}
+                                </button>
+                                
                                 <hr>
                                 <div>
                                     <form method="POST" action="/url/{{$data->short_url}}">
@@ -93,6 +98,9 @@
                                     </form>
                                 </div>
                             </div>
+
+                            @include('url.partials.qrcodemodal', ['url' => $data])
+
                         </div>
                     </div>
                 </div>

--- a/resources/views/url/partials/qrcodemodal.blade.php
+++ b/resources/views/url/partials/qrcodemodal.blade.php
@@ -1,0 +1,24 @@
+<div class="modal fade" id="QRCodeModal" tabindex="-1" role="dialog" aria-labelledby="qrCodeModal" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h1 class="modal-title" id="qrCodeModal">{{ __('url.qrcode_modal') }}</h1>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="modal-body">
+                <div class="d-flex-columns p-2" >
+                    <img class="w-100" src="{{ route('qrcode.svg', $url) }}">
+                    <div class="d-flex">
+                        <a class="flex-grow-1" href="{{ route('qrcode.svg', $url) }}">{{ __('url.qrcode_download') }} .svg</a>
+                        <a class="flex-grow-1" href="{{ route('qrcode.png', $url) }}">{{ __('url.qrcode_download') }} .png</a>
+                    </div>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-dismiss="modal">{{ __('urlhum.close') }}</button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -46,5 +46,7 @@ Route::group(['prefix' => 'url'], function () {
 // We use "show" in place of "edit", because the "real" show is /{url}
 Route::resource('url', 'UrlController')->except(['edit', 'index'])->middleware(['verifycheck', 'honeypot']);
 
-Route::get('/{url}+', 'AnalyticsController@show');
-Route::get('/{url}', 'ViewUrlController@view');
+Route::get('/{url}+', 'AnalyticsController@show')->name('stats');
+Route::get('/{url}.svg', 'QRCodeController@svg')->name('qrcode.svg');
+Route::get('/{url}.png', 'QRCodeController@png')->name('qrcode.png');
+Route::get('/{url}', 'ViewUrlController@view')->name('view');

--- a/tests/Feature/ShortUrlTest.php
+++ b/tests/Feature/ShortUrlTest.php
@@ -14,6 +14,7 @@ use App\Url;
 use App\User;
 use Tests\TestCase;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Storage;
 
 class ShortUrlTest extends TestCase
 {
@@ -236,5 +237,21 @@ class ShortUrlTest extends TestCase
         setting()->set('show_guests_latests_urls', 1);
         $this->get('/url/public')
             ->assertStatus(200);
+    }
+
+    /**
+     * Create .svg file when when that url is hit.
+     *
+     * @return void
+     */
+    public function test_svg_is_created_on_load()
+    {      
+        Storage::fake();
+
+        $this->post('/url', ['url' => 'https://instagram.com', 'customUrl' => 'inst', 'privateUrl' => 0, 'hideUrlStats' => 0]);
+
+        $this->get('/inst.svg')->assertStatus(200);
+
+        Storage::assertExists('qrcodes/inst.svg');
     }
 }


### PR DESCRIPTION
This adds an .svg and .png QR code by navigating to /{shortcode}.svg or /{shortcode}.png
This image is created on first fetch and then cached to the `storage('qrcodes')` directory.

Right now this is accessed in the UI through the Analytics (`{shortcode}+`) and Edit (`url/{shortcode}`) pages.