### PR TITLE
Found Some missing dependencys

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM php:alpine
 
 WORKDIR /app
-RUN apk add --no-cache composer && docker-php-ext-install mysqli pdo pdo_mysql
+RUN apk add --no-cache composer zlib-dev libpng-dev && docker-php-ext-install mysqli pdo pdo_mysql gd
 COPY . ./
 RUN composer install
-RUN echo -e '#!/bin/sh\nuntil nc -z mysql 3306; do sleep 1; done\nphp artisan migrate -n --force\nif [ ! -f "/seed-done" ]; then php artisan db:seed -n --force && php artisan settings:set && touch /seed-done; fi\nphp artisan serve --host=0.0.0.0 --port=8000' > entrypoint.sh && chmod +x entrypoint.sh
+RUN echo -e '#!/bin/sh\nuntil nc -z mysql 3306; do sleep 1; done\nphp artisan migrate -n --force\nif [ ! -f "/seed-done" ]; then php artisan db:seed -n --force && php artisan settings:set && touch /seed-done; fi\nphp artis$
 CMD [ "./entrypoint.sh" ]


### PR DESCRIPTION
Hi,
while trying to use urlhum via the provided docker-compose.yml I encountered some problems during the build and fixed them via trial and error.

# Problems discovered

## Missing php-gd
```
Loading composer repositories with package information
Installing dependencies (including require-dev) from lock file
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Installation request for simplesoftwareio/simple-qrcode 2.0.0 -> satisfiable by simplesoftwareio/simple-qrcode[2.0.0].
    - simplesoftwareio/simple-qrcode 2.0.0 requires ext-gd * -> the requested PHP extension gd is missing from your system.

  To enable extensions, verify that they are enabled in your .ini files:
    -
    - /usr/local/etc/php/conf.d/docker-php-ext-mysqli.ini
    - /usr/local/etc/php/conf.d/docker-php-ext-pdo_mysql.ini
    - /usr/local/etc/php/conf.d/docker-php-ext-sodium.ini
  You can also run `php --ini` inside terminal to see which files are used by PHP in CLI mode.
ERROR: Service 'urlhum' failed to build: The command '/bin/sh -c composer install' returned a non-zero code:
```

Fixed by adding 
`gd` to the php-ext part of line 4
Making it:
`RUN apk add --no-cache composer && docker-php-ext-install mysqli pdo pdo_mysql gd`


## Missing zlib
```
configure: error: Package requirements (zlib) were not met:

Package 'zlib', required by 'virtual:world', not found

Consider adjusting the PKG_CONFIG_PATH environment variable if you
installed software in a non-standard prefix.

Alternatively, you may set the environment variables ZLIB_CFLAGS
and ZLIB_LIBS to avoid the need to call pkg-config.
See the pkg-config man page for more details.
ERROR: Service 'urlhum' failed to build: The command '/bin/sh -c apk add --no-cache composer && docker-php-ext-install mysqli pdo pdo_mysql gd' returned a non-zero code: 1:
```

Fixed by adding 
`zlib-dev` to the apk add part of line 4
Making it:
`RUN apk add --no-cache composer zlib-dev && docker-php-ext-install mysqli pdo pdo_mysql gd`


## Missing libpng
```
configure: error: Package requirements (libpng) were not met:

Package 'libpng', required by 'virtual:world', not found

Consider adjusting the PKG_CONFIG_PATH environment variable if you
installed software in a non-standard prefix.

Alternatively, you may set the environment variables PNG_CFLAGS
and PNG_LIBS to avoid the need to call pkg-config.
See the pkg-config man page for more details.
ERROR: Service 'urlhum' failed to build: The command '/bin/sh -c apk add --no-cache composer zlib-dev && docker-php-ext-install mysqli pdo pdo_mysql gd' returned a non-zero code: 1
```

Fixed by adding 
`libpng-dev` to the apk add part of line 4
Making it:
`RUN apk add --no-cache composer zlib-dev libpng-dev && docker-php-ext-install mysqli pdo pdo_mysql gd`

I am of course open for discussion and also joining the Telegram Group :)