### PR TITLE
Ignored images folder for logo and favicon updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /public/vendor
 /public/argon
 /public/css
+/public/images
 /storage/*.key
 /vendor
 .env


### PR DESCRIPTION
When using a custom logo and favicon, the images are being placed in the public/images folder and git shows them as new files. They should be untracked from git. As the existing logo and favicon are already in git, they won't be affected.